### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,47 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: circleci/node:12.16
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Set up Docker; see https://circleci.com/docs/2.0/building-docker-images/
+      - setup_remote_docker:
+          version: 18.09.3
+
+      # Build unit test Docker image
+      - run:
+          name: build unit test Docker image
+          command: |
+            docker build -t grpc-web-example/test .
+
+      # Build gRPC server Docker image
+      - run:
+          name: build gRPC server Docker image
+          command: |
+            git clone https://github.com/msmolens/python-grpc-ssl-example.git ~/python-grpc-ssl-example
+            docker build -t python-grpc-ssl-example ~/python-grpc-ssl-example
+
+      # Set up proxy
+      - run:
+          name: set up proxy
+          command: |
+            docker build -t grpc-web-example/envoy -f ./envoy.Dockerfile .
+
+      # Run gRPC server, proxy, and tests
+      - run:
+          name: run tests
+          command: |
+            docker run -d --name python-grpc-ssl-example python-grpc-ssl-example python /opt/app/shopping_list_server.py --no-use-tls --port 9090
+            docker run -d --network container:python-grpc-ssl-example grpc-web-example/envoy
+            docker run --network container:python-grpc-ssl-example grpc-web-example/test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:12-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn install
+
+# Copy app files
+COPY . . 
+
+# Switch to node user
+USER node
+
+CMD [ "yarn", "run", "test:unit"] 

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -41,4 +41,4 @@ static_resources:
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    hosts: [{ socket_address: { address: localhost, port_value: 9090 }}]
+    hosts: [{ socket_address: { address: 0.0.0.0, port_value: 9090 }}]


### PR DESCRIPTION
Run unit tests in CircleCI. The python-grpc-ssl-example server and Envoy
Proxy containers are started in the background while the unit test
container runs in the foreground. All the containers share a network.